### PR TITLE
Avoid input border flickering

### DIFF
--- a/lib/src/flutter_search_bar_base.dart
+++ b/lib/src/flutter_search_bar_base.dart
@@ -174,7 +174,7 @@ class SearchBar {
                     color: textColor,
                     fontSize: 16.0
                 ),
-                border: null
+                border: InputBorder.none
             ),
             onChanged: this.onChanged,
             onSubmitted: (String val) async {


### PR DESCRIPTION
Changed InputDecoration border to be InputBorder.none instead of null. This avoids a weird flickering when opening the search.

See https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/input_decorator.dart#L2510